### PR TITLE
Switch to using a threading.local for _AsyncLib.

### DIFF
--- a/asks/__init__.py
+++ b/asks/__init__.py
@@ -10,9 +10,10 @@ with its similar design and approach to async in python. Why not support both?
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=wrong-import-position
 # pylint: disable=no-member
+import threading
 
 
-class _AsyncLib:
+class _AsyncLib(threading.local):
     '''
     When _async_lib.something is requested, _async_lib.__dict__['something']
     is checked before _async_lib.__getattr__('something')


### PR DESCRIPTION
This allows using a different library in a different thread, if such a use case would come up (similar to asyncio's event loop policy).

It'd also be nice to be able to separate the _AsyncLib code out into something separate for other libraries to use, but that's out of scope for this PR.