### PR TITLE
fixed not reading response body when connection: close

### DIFF
--- a/asks/request.py
+++ b/asks/request.py
@@ -544,13 +544,20 @@ class Request:
                 except (KeyError, AttributeError):
                     resp_data['headers']['set-cookie'] = [str(header[1],
                                                           'utf-8')]
+
+        # check whether we should receive body according to RFC 7230
+        # https://tools.ietf.org/html/rfc7230#section-3.3.3
         get_body = False
         try:
             if int(resp_data['headers']['content-length']) > 0:
                 get_body = True
         except KeyError:
-            if resp_data['headers']['transfer-encoding'] == 'chunked':
-                get_body = True
+            try:
+                if resp_data['headers']['transfer-encoding'] == 'chunked':
+                    get_body = True
+            except KeyError:
+                if resp_data['headers']['connection'] == 'close':
+                    get_body = True
 
         if get_body:
             if self.callback is not None:

--- a/tests/test_asks_curio.py
+++ b/tests/test_asks_curio.py
@@ -190,6 +190,13 @@ async def test_stream():
     assert len(img) == 8090
 
 
+# Test connection close without content-length and transfer-encoding
+@curio_run
+async def test_connection_close():
+    r = await asks.get('https://www.ua-region.com.ua/search/?q=rrr')
+    assert r.text
+
+
 # Test callback
 callback_data = b''
 async def callback_example(chunk):

--- a/tests/test_asks_trio.py
+++ b/tests/test_asks_trio.py
@@ -193,6 +193,13 @@ async def test_stream():
     assert len(img) == 8090
 
 
+# Test connection close without content-length and transfer-encoding
+@trio_run
+async def test_connection_close():
+    r = await asks.get('https://www.ua-region.com.ua/search/?q=rrr')
+    assert r.text
+
+
 # Test callback
 callback_data = b''
 async def callback_example(chunk):


### PR DESCRIPTION
According to [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.3.3):

> Otherwise, this is a response message without a declared message body length, so the message body length is determined by the number of octets received prior to the server closing the connection.

when we can not determine the content length, we have to assume there is a body, and continue to read until the server closes the connection.

fixed #32 