### PR TITLE
use less httpbin/google in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ python:
 
 install:
    - ./setup.py develop
-   - pip3 install pylint
+   - pip3 install pytest-httpbin
    - pip3 install git+https://github.com/python-trio/trio.git
    - pip3 install git+https://github.com/dabeaz/curio.git
+   - pip3 install pylint
 
 script:
   - pytest --verbose --tb=native

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "3.6"
   - "nightly"
 
+cache: pip
+
 install:
    - ./setup.py develop
    - pip3 install pytest-httpbin

--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -28,7 +28,7 @@ from .errors import TooManyRedirects
 
 
 _BOUNDARY = "8banana133744910kmmr13ay5fa56" + str(randint(1e3, 9e3))
-_WWX_MATCH = re.compile(r'\Aww.\.')  # careful now
+_WWX_MATCH = re.compile(r'\Aww.\.')
 _MAX_BYTES = 4096
 
 

--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -8,7 +8,7 @@ from functools import partialmethod
 
 from asks import _async_lib
 
-from .request import Request
+from .request_object import Request
 from .cookie_utils import CookieTracker
 from .req_structs import SocketQ
 from .utils import get_netloc_port

--- a/pylintrc
+++ b/pylintrc
@@ -87,7 +87,7 @@ ignored-classes=Response,socket
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
-generated-members=__members__,h11.CLIENT
+generated-members=__members__,h11.CLIENT,httpbin
 
 
 [LOGGING]

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
     url='https://github.com/theelous3/asks',
     packages=['asks'],
     install_requires=['h11'],
-    tests_require=['pytest'],
+    tests_require=['pytest', 'pytest-httpbin', 'curio', 'trio'],
     classifiers=['Programming Language :: Python :: 3']
 )

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -164,12 +164,6 @@ class BaseTests:
         assert len(img) == 8090
 
 
-    # Test connection close without content-length and transfer-encoding
-    async def test_connection_close(self):
-        r = await asks.get('https://www.ua-region.com.ua/search/?q=rrr')
-        assert r.text
-
-
     async def test_callback(self):
         callback_data = b''
         async def callback_example(chunk):

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -36,45 +36,45 @@ class BaseTests:
 
 
     async def test_http_get(self):
-        r = await asks.get('http://httpbin.org/get')
+        r = await asks.get(self.httpbin.url + '/get')
         assert r.status_code == 200
 
 
     # Redirect tests
     async def test_http_redirect(self):
-        r = await asks.get('http://httpbin.org/redirect/1')
+        r = await asks.get(self.httpbin.url + '/redirect/1')
         assert len(r.history) == 1
 
         # make sure history doesn't persist across responses
         r.history.append('not a response obj')
-        r = await asks.get('http://httpbin.org/redirect/1')
+        r = await asks.get(self.httpbin.url + '/redirect/1')
         assert len(r.history) == 1
 
 
     async def test_http_max_redirect_error(self):
         with pytest.raises(TooManyRedirects):
-            await asks.get('http://httpbin.org/redirect/2', max_redirects=1)
+            await asks.get(self.httpbin.url + '/redirect/2', max_redirects=1)
 
 
     async def test_http_max_redirect(self):
-        r = await asks.get('http://httpbin.org/redirect/1', max_redirects=2)
+        r = await asks.get(self.httpbin.url + '/redirect/1', max_redirects=2)
         assert r.status_code == 200
 
 
     # Timeout tests
     async def test_http_timeout_error(self):
         with pytest.raises(RequestTimeout):
-            await asks.get('http://httpbin.org/delay/1', timeout=1)
+            await asks.get(self.httpbin.url + '/delay/1', timeout=1)
 
 
     async def test_http_timeout(self):
-        r = await asks.get('http://httpbin.org/delay/1', timeout=10)
+        r = await asks.get(self.httpbin.url + '/delay/1', timeout=10)
         assert r.status_code == 200
 
 
     # Param set test
     async def test_param_dict_set(self):
-        r = await asks.get('http://httpbin.org/response-headers',
+        r = await asks.get(self.httpbin.url + '/response-headers',
                            params={'cheese': 'the best'})
         j = r.json()
         assert j['cheese'] == 'the best'
@@ -82,7 +82,7 @@ class BaseTests:
 
     # Data set test
     async def test_data_dict_set(self):
-        r = await asks.post('http://httpbin.org/post',
+        r = await asks.post(self.httpbin.url + '/post',
                             data={'cheese': 'please'})
         j = r.json()
         assert j['form']['cheese'] == 'please'
@@ -90,7 +90,7 @@ class BaseTests:
 
     # Cookie send test
     async def test_cookie_dict_send(self):
-        r = await asks.get('http://httpbin.org/cookies',
+        r = await asks.get(self.httpbin.url + '/cookies',
                            cookies={'Test-Cookie': 'Test Cookie Value'})
         j = r.json()
         assert 'Test-Cookie' in j['cookies']
@@ -98,7 +98,7 @@ class BaseTests:
 
     # Custom headers test
     async def test_header_set(self):
-        r = await asks.get('http://httpbin.org/headers',
+        r = await asks.get(self.httpbin.url + '/headers',
                            headers={'Asks-Header': 'Test Header Value'})
         j = r.json()
         assert 'Asks-Header' in j['headers']
@@ -106,14 +106,14 @@ class BaseTests:
 
 
     async def test_file_send_single(self):
-        r = await asks.post('http://httpbin.org/post',
+        r = await asks.post(self.httpbin.url + '/post',
                             files={'file_1': TEST_FILE1})
         j = r.json()
         assert j['files']['file_1'] == 'Compooper'
 
 
     async def test_file_send_double(self):
-        r = await asks.post('http://httpbin.org/post',
+        r = await asks.post(self.httpbin.url + '/post',
                             files={'file_1': TEST_FILE1,
                                    'file_2': TEST_FILE2})
         j = r.json()
@@ -121,7 +121,7 @@ class BaseTests:
 
 
     async def test_file_and_data_send(self):
-        r = await asks.post('http://httpbin.org/post',
+        r = await asks.post(self.httpbin.url + '/post',
                             files={'file_1': TEST_FILE1,
                                    'data_1': 'watwatwatwat'})
         j = r.json()
@@ -130,7 +130,7 @@ class BaseTests:
 
     # JSON send test
     async def test_json_send(self):
-        r = await asks.post('http://httpbin.org/post',
+        r = await asks.post(self.httpbin.url + '/post',
                             json={'key_1': True,
                                   'key_2': 'cheesestring'})
         j = r.json()
@@ -140,25 +140,25 @@ class BaseTests:
 
     # Test decompression
     async def test_gzip(self):
-        r = await asks.get('http://httpbin.org/gzip')
+        r = await asks.get(self.httpbin.url + '/gzip')
         assert r.text
 
 
     async def test_deflate(self):
-        r = await asks.get('http://httpbin.org/deflate')
+        r = await asks.get(self.httpbin.url + '/deflate')
         assert r.text
 
 
     # Test chunked TE
     async def test_chunked_te(self):
-        r = await asks.get('http://httpbin.org/range/3072')
+        r = await asks.get(self.httpbin.url + '/range/3072')
         assert r.status_code == 200
 
 
     # Test stream response
     async def test_stream(self):
         img = b''
-        r = await asks.get('http://httpbin.org/image/png', stream=True)
+        r = await asks.get(self.httpbin.url + '/image/png', stream=True)
         async for chunk in r.body:
             img += chunk
         assert len(img) == 8090
@@ -176,7 +176,7 @@ class BaseTests:
             nonlocal callback_data
             callback_data += chunk
 
-        await asks.get('http://httpbin.org/image/png',
+        await asks.get(self.httpbin.url + '/image/png',
                        callback=callback_example)
         assert len(callback_data) == 8090
 
@@ -200,6 +200,6 @@ async def session_t_stateful_double_worker(s):
     assert r.status_code == 200
 
 
-async def session_t_smallpool(s):
-    r = await s.get('http://httpbin.org/get')
+async def session_t_smallpool(s, httpbin):
+    r = await s.get(httpbin.url + '/get')
     assert r.status_code == 200

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -185,12 +185,7 @@ async def hsession_t_smallpool(s):
 
 # Test stateful Session
 async def hsession_t_stateful(s):
-    r = await s.get()
-    assert r.status_code == 200
-
-
-async def session_t_stateful_double_worker(s):
-    r = await s.get()
+    r = await s.get(path='/cookies/set?cow=moo')
     assert r.status_code == 200
 
 

--- a/tests/test_asks_curio.py
+++ b/tests/test_asks_curio.py
@@ -1,4 +1,5 @@
 import curio
+import pytest_httpbin
 
 import asks
 from . import base_tests
@@ -10,6 +11,7 @@ def curio_run(func):
     return func_wrapper
 
 
+@pytest_httpbin.use_class_based_httpbin
 class TestAsksCurio(metaclass=base_tests.TestAsksMeta):
     run = curio_run
 
@@ -21,7 +23,7 @@ class TestAsksCurio(metaclass=base_tests.TestAsksMeta):
     @curio_run
     async def test_hsession_smallpool(self):
         from asks.sessions import Session
-        s = Session('http://httpbin.org', connections=2)
+        s = Session(self.httpbin.url, connections=2)
         async with curio.TaskGroup() as g:
             for _ in range(10):
                 await g.spawn(base_tests.hsession_t_smallpool(s))
@@ -55,4 +57,4 @@ class TestAsksCurio(metaclass=base_tests.TestAsksMeta):
         from asks.sessions import Session
         s = Session(connections=2)
         for _ in range(10):
-            await curio.spawn(base_tests.session_t_smallpool(s))
+            await curio.spawn(base_tests.session_t_smallpool(s, self.httpbin))

--- a/tests/test_asks_curio.py
+++ b/tests/test_asks_curio.py
@@ -32,20 +32,23 @@ class TestAsksCurio(metaclass=base_tests.TestAsksMeta):
     @curio_run
     async def test_session_stateful(self):
         from asks.sessions import Session
-        s = Session(
-            'https://google.ie', persist_cookies=True)
+        s = Session(self.httpbin.url, persist_cookies=True)
         async with curio.TaskGroup() as g:
             await g.spawn(base_tests.hsession_t_stateful(s))
-        assert 'www.google.ie' in s._cookie_tracker_obj.domain_dict.keys()
+        domain = f'{self.httpbin.host}:{self.httpbin.port}'
+        cookies = s._cookie_tracker_obj.domain_dict[domain]
+        assert len(cookies) == 1
+        assert cookies[0].name == 'cow'
+        assert cookies[0].value == 'moo'
 
 
     @curio_run
     async def test_session_stateful_double(self):
         from asks.sessions import Session
-        s = Session('https://google.ie', persist_cookies=True)
+        s = Session(self.httpbin.url, persist_cookies=True)
         async with curio.TaskGroup() as g:
             for _ in range(4):
-                await g.spawn(base_tests.session_t_stateful_double_worker(s))
+                await g.spawn(base_tests.hsession_t_stateful(s))
 
 
     # Session Tests

--- a/tests/test_asks_trio.py
+++ b/tests/test_asks_trio.py
@@ -1,3 +1,4 @@
+import pytest_httpbin
 import trio
 
 import asks
@@ -10,6 +11,7 @@ def trio_run(func):
     return func_wrapper
 
 
+@pytest_httpbin.use_class_based_httpbin
 class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
     run = trio_run
 
@@ -21,7 +23,7 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
     @trio_run
     async def test_hsession_smallpool(self):
         from asks.sessions import Session
-        s = Session('http://httpbin.org', connections=2)
+        s = Session(self.httpbin.url, connections=2)
         async with trio.open_nursery() as n:
             for _ in range(10):
                 n.spawn(base_tests.hsession_t_smallpool, s)
@@ -56,4 +58,4 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
         s = Session(connections=2)
         async with trio.open_nursery() as n:
             for _ in range(10):
-                n.spawn(base_tests.session_t_smallpool, s)
+                n.spawn(base_tests.session_t_smallpool, s, self.httpbin)

--- a/tests/test_asks_trio.py
+++ b/tests/test_asks_trio.py
@@ -32,20 +32,23 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
     @trio_run
     async def test_session_stateful(self):
         from asks.sessions import Session
-        s = Session(
-            'https://google.ie', persist_cookies=True)
+        s = Session(self.httpbin.url, persist_cookies=True)
         async with trio.open_nursery() as n:
             n.spawn(base_tests.hsession_t_stateful, s)
-        assert 'www.google.ie' in s._cookie_tracker_obj.domain_dict.keys()
+        domain = f'{self.httpbin.host}:{self.httpbin.port}'
+        cookies = s._cookie_tracker_obj.domain_dict[domain]
+        assert len(cookies) == 1
+        assert cookies[0].name == 'cow'
+        assert cookies[0].value == 'moo'
 
 
     @trio_run
     async def test_session_stateful_double(self):
         from asks.sessions import Session
-        s = Session('https://google.ie', persist_cookies=True)
+        s = Session(self.httpbin.url, persist_cookies=True)
         async with trio.open_nursery() as n:
             for _ in range(4):
-                n.spawn(base_tests.session_t_stateful_double_worker, s)
+                n.spawn(base_tests.hsession_t_stateful, s)
 
 
     # Session Tests

--- a/tests/test_request_object.py
+++ b/tests/test_request_object.py
@@ -1,0 +1,30 @@
+# pylint: disable=no-member
+
+import h11
+
+from asks.request_object import Request
+
+def _catch_response(monkeypatch, headers, data):
+    req = Request(None, None, None, None)
+    events = [
+        h11._events.Response(status_code=200, headers=headers),
+        h11._events.Data(data=data),
+        h11._events.EndOfMessage(),
+    ]
+    async def _recv_event(hconn):
+        return events.pop(0)
+    monkeypatch.setattr(req, '_recv_event', _recv_event)
+    cr = req._catch_response(None)
+    try:
+        cr.send(None)
+    except StopIteration as e:
+        response = e.value
+    return response
+
+def test_http1_1(monkeypatch):
+    response = _catch_response(monkeypatch, [('Content-Length', '5')], b'hello')
+    assert response.body == b'hello'
+
+def test_http1_0(monkeypatch):
+    response = _catch_response(monkeypatch, [('Connection', 'close')], b'hello')
+    assert response.body == b'hello'


### PR DESCRIPTION
https://github.com/raylu/asks/commit/1161b97bff9c29457e71812d5f304d00dd23a0e4 is a pretty complex replacement for #34, but it also tests a much smaller unit of the code

with this, there are just [3 tests](https://github.com/theelous3/asks/blob/e184d8adfc306a89b5c69502a69b6ad4edfa6bd9/tests/base_tests.py#L23-L35) that reach out to the internet

also,
- turn on the pip [cache](https://docs.travis-ci.com/user/caching/) in travis
- rename `request.py` to `request_object.py`