### PR TITLE
Connection: close is case insensitive

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -556,7 +556,7 @@ class Request:
                 if resp_data['headers']['transfer-encoding'] == 'chunked':
                     get_body = True
             except KeyError:
-                if resp_data['headers']['connection'] == 'close':
+                if resp_data['headers']['connection'].lower() == 'close':
                     get_body = True
 
         if get_body:
@@ -566,7 +566,7 @@ class Request:
                 if 199 < resp_data['status_code'] < 300:
                     if not ((self.scheme == self.initial_scheme and
                             self.netloc == self.initial_netloc) or
-                            resp_data['headers']['connection'] == 'close'):
+                            resp_data['headers']['connection'].lower() == 'close'):
                         self.sock._active = False
                     resp_data['body'] = StreamBody(self.session,
                                                    hconnection,


### PR DESCRIPTION
test_chunked_te was failing for me because httpbin was sending a
header like

    connection: Close

and then asks was getting confused because it was looking for "close",
not "Close". However, these are equivalent, because "Connection
options are case-insensitive" -- RFC 7230 section 6.1.