### PR TITLE
Fix deprecation warnings when running against trio master

### DIFF
--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -183,10 +183,7 @@ class BaseSession:
 
             try:
                 async with _async_lib.timeout_after(timeout):
-                    async with _async_lib.task_manager() as m:
-                        response_task = await m.spawn(
-                            req_obj.make_request)
-                    sock, r = response_task.result
+                    sock, r = await req_obj.make_request()
             except _async_lib.TaskTimeout:
                 raise RequestTimeout
 
@@ -194,9 +191,7 @@ class BaseSession:
 
             try:
                 with _async_lib.timeout_after(timeout):
-                    async with _async_lib.task_manager() as m:
-                        response_task = m.spawn(req_obj.make_request)
-                    sock, r = response_task.result.unwrap()
+                    sock, r = await req_obj.make_request()
             except _async_lib.TaskTimeout:
                 raise RequestTimeout
 

--- a/tests/test_asks_trio.py
+++ b/tests/test_asks_trio.py
@@ -26,7 +26,7 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
         s = Session(self.httpbin.url, connections=2)
         async with trio.open_nursery() as n:
             for _ in range(10):
-                n.spawn(base_tests.hsession_t_smallpool, s)
+                n.start_soon(base_tests.hsession_t_smallpool, s)
 
 
     @trio_run
@@ -34,7 +34,7 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
         from asks.sessions import Session
         s = Session(self.httpbin.url, persist_cookies=True)
         async with trio.open_nursery() as n:
-            n.spawn(base_tests.hsession_t_stateful, s)
+            n.start_soon(base_tests.hsession_t_stateful, s)
         domain = '{}:{}'.format(self.httpbin.host, self.httpbin.port)
         cookies = s._cookie_tracker_obj.domain_dict[domain]
         assert len(cookies) == 1
@@ -48,7 +48,7 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
         s = Session(self.httpbin.url, persist_cookies=True)
         async with trio.open_nursery() as n:
             for _ in range(4):
-                n.spawn(base_tests.hsession_t_stateful, s)
+                n.start_soon(base_tests.hsession_t_stateful, s)
 
 
     # Session Tests
@@ -61,4 +61,4 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
         s = Session(connections=2)
         async with trio.open_nursery() as n:
             for _ in range(10):
-                n.spawn(base_tests.session_t_smallpool, s, self.httpbin)
+                n.start_soon(base_tests.session_t_smallpool, s, self.httpbin)


### PR DESCRIPTION
Notice that this removes some unnecessary complication from
timeout_manager because that was easier than trying to fix it.

I'd actually suggest removing timeout support from asks entirely,
since ATM it's totally redundant with just having the user wrap the
request in some kind of timeout block, and that's the more general and
idiomatic solution anyway in both curio and trio. But that seemed like
a bit much to do without checking first :-)