### PR TITLE
Use multio instead of the built-in asynclib handler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
    - pip3 install git+https://github.com/python-trio/trio.git
    - pip3 install git+https://github.com/dabeaz/curio.git
    - pip3 install pylint
+   - pip3 install multio
 
 script:
   - pytest --verbose --tb=native

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Note: Currently supports trio's development branch. You can install this by doin
 # A little silly to async one request, but not without its use!
 import asks
 import curio
-import multio
-multio.init('curio')
+asks.init('curio')
 
 async def example():
     r = await asks.get('https://example.org')
@@ -45,8 +44,7 @@ curio.run(example())
 
 import asks
 import trio
-import multio
-multio.init('trio')
+asks.init('trio')
 
 path_list = ['a', 'list', 'of', '1000', 'paths']
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Above you'll find detailed docs with a large number of simple examples to help y
 
 ## Installation
 
-*Requires: Python 3.6.*
+*Requires: Python 3.5.*
 
 `pip install asks`
 
@@ -29,7 +29,8 @@ Note: Currently supports trio's development branch. You can install this by doin
 # A little silly to async one request, but not without its use!
 import asks
 import curio
-asks.init('curio')
+import multio
+multio.init('curio')
 
 async def example():
     r = await asks.get('https://example.org')
@@ -44,7 +45,8 @@ curio.run(example())
 
 import asks
 import trio
-asks.init('trio')
+import multio
+multio.init('trio')
 
 path_list = ['a', 'list', 'of', '1000', 'paths']
 

--- a/asks/__init__.py
+++ b/asks/__init__.py
@@ -1,100 +1,11 @@
-'''
-Alright, you're probably having a heart attack looking at this right now.
-Just breathe, and it will be ok, I promise!
-
-asks was initially created just to support curio, until trio came along
-with its similar design and approach to async in python. Why not support both?
-'''
-
 # pylint: disable=wildcard-import
 # pylint: disable=wrong-import-position
-import threading
+
+# alias multio init for backwards compat
+import multio
+init = multio.init
 
 
-class _AsyncLib(threading.local):
-    def __init__(self):
-        self.aopen = None
-        self.open_connection = None
-        self.sleep = None
-        self.task_manager = None
-        self.TaskTimeout = None
-        self.timeout_after = None
-        self.sendall = None
-        self.recv = None
-        super().__init__()
-
-    '''
-    When _async_lib.something is requested, _async_lib.__dict__['something']
-    is checked before _async_lib.__getattr__('something')
-    '''
-    def __getattr__(self, attr):
-        # the __dict__ is empty when a new instance has just been created
-        if not self.__dict__:
-            raise RuntimeError("asks.init() wasn't called")
-
-
-# So, the idea here is that asks, after import, must be told explicitly which
-# event loop to use. Upon first import, asks has _AsyncLib which is an empty
-# shell. Upon asks' initialisation the instance of _AsyncLib asks uses is
-# populated either with functions and classes directly from the chosen async
-# lib, or with wrappers around those functions and classes such that they share
-# the same API to the extent asks requires.
-
-# This results in a meeting point between the two libraries which asks can use
-# arbitrarily. (You can even run a trio event loop, and then run the same
-# functions with curio! Not recommended, but hey. It's fun.)
-
-# For the sake of simplicity, where possible, the methods of _AsyncLib use the
-# curio name. For example, TaskTimeout from curio rather than TooSlowError from
-# trio. This is not indicative of any preference to the libraries themselves;
-# it just required fewer changes to asks' internals to implement.
-
-# the instance asks uses internally
-_async_lib = _AsyncLib()
-
-
-def init(lib_name):
-    '''
-    Must be called at some point after asks import and before your event loop
-    is run.
-
-    Populates the _async_lib instance of _AsyncLib with methods relevant to the
-    async library you are using.
-
-    Args:
-        lib_name (str): Either 'curio' or 'trio'.
-    '''
-    if lib_name == 'curio':
-        import curio
-        from ._event_loop_wrappers import (curio_sendall,
-                                           curio_recv)
-        _async_lib.aopen = curio.aopen
-        _async_lib.open_connection = curio.open_connection
-        _async_lib.sleep = curio.sleep
-        _async_lib.task_manager = curio.TaskGroup
-        _async_lib.TaskTimeout = curio.TaskTimeout
-        _async_lib.timeout_after = curio.timeout_after
-        _async_lib.sendall = curio_sendall
-        _async_lib.recv = curio_recv
-
-    elif lib_name == 'trio':
-        import trio
-        from ._event_loop_wrappers import (trio_open_connection,
-                                           trio_send_all,
-                                           trio_receive_some)
-        _async_lib.aopen = trio.open_file
-        _async_lib.sleep = trio.sleep
-        _async_lib.task_manager = trio.open_nursery
-        _async_lib.TaskTimeout = trio.TooSlowError
-        _async_lib.timeout_after = trio.fail_after
-        _async_lib.open_connection = trio_open_connection
-        _async_lib.sendall = trio_send_all
-        _async_lib.recv = trio_receive_some
-
-    else:
-        raise RuntimeError('{} is not a supported library.'.format(lib_name))
-
-
+from .auth import *
 from .base_funcs import *
 from .sessions import *
-from .auth import *

--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -489,7 +489,7 @@ class Request:
 
     async def _file_manager(self, path):
         try:
-             async with asynclib.aopen(path, 'rb') as f:
+            async with asynclib.aopen(path, 'rb') as f:
                 return b''.join(await f.readlines()) + b'\r\n'
         except AttributeError:
             async with await asynclib.aopen(path, 'rb') as f:

--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -19,7 +19,7 @@ import re
 
 import h11
 from h11 import RemoteProtocolError
-from asks import _async_lib
+from multio import asynclib
 
 from .auth import PreResponseAuth, PostResponseAuth
 from .req_structs import CaseInsensitiveDict as c_i_dict
@@ -489,10 +489,10 @@ class Request:
 
     async def _file_manager(self, path):
         try:
-            async with _async_lib.aopen(path, 'rb') as f:
+             async with asynclib.aopen(path, 'rb') as f:
                 return b''.join(await f.readlines()) + b'\r\n'
         except AttributeError:
-            async with await _async_lib.aopen(path, 'rb') as f:
+            async with await asynclib.aopen(path, 'rb') as f:
                 return b''.join(await f.readlines()) + b'\r\n'
 
     def _queryify(self, query):
@@ -590,7 +590,7 @@ class Request:
             event = hconnection.next_event()
             if event is h11.NEED_DATA:
                 hconnection.receive_data(
-                    (await _async_lib.recv(self.sock, 10000)))
+                    (await asynclib.recv(self.sock, 10000)))
                 continue
             return event
 
@@ -603,10 +603,10 @@ class Request:
             package (list of str): The header package.
             body (str): The str representation of the body.
         '''
-        await _async_lib.sendall(self.sock, hconnection.send(request_bytes))
+        await asynclib.sendall(self.sock, hconnection.send(request_bytes))
         if body_bytes is not None:
-            await _async_lib.sendall(self.sock, hconnection.send(body_bytes))
-        await _async_lib.sendall(
+            await asynclib.sendall(self.sock, hconnection.send(body_bytes))
+        await asynclib.sendall(
             self.sock, hconnection.send(h11.EndOfMessage()))
 
     async def _auth_handler_pre(self):

--- a/asks/response_objects.py
+++ b/asks/response_objects.py
@@ -7,7 +7,7 @@ from zlib import decompress as zdecompress
 from async_generator import async_generator, yield_
 import h11
 
-from asks import _async_lib
+from multio import asynclib
 
 
 class Response:
@@ -172,7 +172,7 @@ class StreamBody:
             event = self.hconnection.next_event()
             if event is h11.NEED_DATA:
                 self.hconnection.receive_data(
-                    (await _async_lib.recv(self.sock, 10000)))
+                    (await asynclib.recv(self.sock, 10000)))
                 continue
             return event
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Mark Jameson - aka theelous3',
     url='https://github.com/theelous3/asks',
     packages=['asks'],
-    install_requires=['h11', 'async_generator'],
+    install_requires=['h11', 'async_generator', 'multio'],
     tests_require=['pytest', 'pytest-httpbin', 'curio', 'trio'],
     classifiers=['Programming Language :: Python :: 3']
 )

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -9,6 +9,7 @@ TEST_DIR = path.dirname(path.abspath(__file__))
 TEST_FILE1 = path.join(TEST_DIR, 'test_file1.txt')
 TEST_FILE2 = path.join(TEST_DIR, 'test_file2')
 
+
 class TestAsksMeta(type):
     def __new__(mcs, clsname, parents, dct):
         run = dct['run']
@@ -24,21 +25,17 @@ class BaseTests:
         r = await asks.get('https://www.reddit.com')
         assert r.status_code == 200
 
-
     async def test_bad_www_and_schema_get(self):
         r = await asks.get('http://reddit.com')
         assert r.status_code == 200
-
 
     async def test_https_get_alt(self):
         r = await asks.get('https://www.google.ie')
         assert r.status_code == 200
 
-
     async def test_http_get(self):
         r = await asks.get(self.httpbin.url + '/get')
         assert r.status_code == 200
-
 
     # Redirect tests
     async def test_http_redirect(self):
@@ -50,27 +47,22 @@ class BaseTests:
         r = await asks.get(self.httpbin.url + '/redirect/1')
         assert len(r.history) == 1
 
-
     async def test_http_max_redirect_error(self):
         with pytest.raises(TooManyRedirects):
             await asks.get(self.httpbin.url + '/redirect/2', max_redirects=1)
 
-
     async def test_http_max_redirect(self):
         r = await asks.get(self.httpbin.url + '/redirect/1', max_redirects=2)
         assert r.status_code == 200
-
 
     # Timeout tests
     async def test_http_timeout_error(self):
         with pytest.raises(RequestTimeout):
             await asks.get(self.httpbin.url + '/delay/1', timeout=1)
 
-
     async def test_http_timeout(self):
         r = await asks.get(self.httpbin.url + '/delay/1', timeout=10)
         assert r.status_code == 200
-
 
     # Param set test
     async def test_param_dict_set(self):
@@ -79,7 +71,6 @@ class BaseTests:
         j = r.json()
         assert j['cheese'] == 'the best'
 
-
     # Data set test
     async def test_data_dict_set(self):
         r = await asks.post(self.httpbin.url + '/post',
@@ -87,14 +78,12 @@ class BaseTests:
         j = r.json()
         assert j['form']['cheese'] == 'please'
 
-
     # Cookie send test
     async def test_cookie_dict_send(self):
         r = await asks.get(self.httpbin.url + '/cookies',
                            cookies={'Test-Cookie': 'Test Cookie Value'})
         j = r.json()
         assert 'Test-Cookie' in j['cookies']
-
 
     # Custom headers test
     async def test_header_set(self):
@@ -104,56 +93,54 @@ class BaseTests:
         assert 'Asks-Header' in j['headers']
         assert 'cOntenT-tYPe' in r.headers
 
-
     async def test_file_send_single(self):
         r = await asks.post(self.httpbin.url + '/post',
                             files={'file_1': TEST_FILE1})
         j = r.json()
         assert j['files']['file_1'] == 'Compooper'
 
-
     async def test_file_send_double(self):
         r = await asks.post(self.httpbin.url + '/post',
-                            files={'file_1': TEST_FILE1,
-                                   'file_2': TEST_FILE2})
+                            files={
+                                'file_1': TEST_FILE1,
+                                'file_2': TEST_FILE2
+                            })
         j = r.json()
         assert j['files']['file_2'] == 'My slug <3'
 
-
     async def test_file_and_data_send(self):
         r = await asks.post(self.httpbin.url + '/post',
-                            files={'file_1': TEST_FILE1,
-                                   'data_1': 'watwatwatwat'})
+                            files={
+                                'file_1': TEST_FILE1,
+                                'data_1': 'watwatwatwat'
+                            })
         j = r.json()
         assert j['form']['data_1'] == 'watwatwatwat'
-
 
     # JSON send test
     async def test_json_send(self):
         r = await asks.post(self.httpbin.url + '/post',
-                            json={'key_1': True,
-                                  'key_2': 'cheesestring'})
+                            json={
+                                'key_1': True,
+                                'key_2': 'cheesestring'
+                            })
         j = r.json()
         assert j['json']['key_1'] is True
         assert j['json']['key_2'] == 'cheesestring'
-
 
     # Test decompression
     async def test_gzip(self):
         r = await asks.get(self.httpbin.url + '/gzip')
         assert r.text
 
-
     async def test_deflate(self):
         r = await asks.get(self.httpbin.url + '/deflate')
         assert r.text
-
 
     # Test chunked TE
     async def test_chunked_te(self):
         r = await asks.get(self.httpbin.url + '/range/3072')
         assert r.status_code == 200
-
 
     # Test stream response
     async def test_stream(self):
@@ -163,9 +150,9 @@ class BaseTests:
             img += chunk
         assert len(img) == 8090
 
-
     async def test_callback(self):
         callback_data = b''
+
         async def callback_example(chunk):
             nonlocal callback_data
             callback_data += chunk

--- a/tests/test_asks_curio.py
+++ b/tests/test_asks_curio.py
@@ -1,13 +1,14 @@
 import curio
+import multio
 import pytest_httpbin
 
-import asks
 from . import base_tests
 
 
 def curio_run(func):
     def func_wrapper(*args, **kwargs):
         return curio.run(func(*args, **kwargs))
+
     return func_wrapper
 
 
@@ -17,8 +18,7 @@ class TestAsksCurio(metaclass=base_tests.TestAsksMeta):
 
     @classmethod
     def setup_class(cls):
-        asks.init('curio')
-
+        multio.init('curio')
 
     @curio_run
     async def test_hsession_smallpool(self):
@@ -27,7 +27,6 @@ class TestAsksCurio(metaclass=base_tests.TestAsksMeta):
         async with curio.TaskGroup() as g:
             for _ in range(10):
                 await g.spawn(base_tests.hsession_t_smallpool(s))
-
 
     @curio_run
     async def test_session_stateful(self):
@@ -41,7 +40,6 @@ class TestAsksCurio(metaclass=base_tests.TestAsksMeta):
         assert cookies[0].name == 'cow'
         assert cookies[0].value == 'moo'
 
-
     @curio_run
     async def test_session_stateful_double(self):
         from asks.sessions import Session
@@ -49,7 +47,6 @@ class TestAsksCurio(metaclass=base_tests.TestAsksMeta):
         async with curio.TaskGroup() as g:
             for _ in range(4):
                 await g.spawn(base_tests.hsession_t_stateful(s))
-
 
     # Session Tests
     # ==============

--- a/tests/test_asks_trio.py
+++ b/tests/test_asks_trio.py
@@ -1,13 +1,14 @@
+import multio
 import pytest_httpbin
 import trio
 
-import asks
 from . import base_tests
 
 
 def trio_run(func):
     def func_wrapper(*args, **kwargs):
         return trio.run(func, *args, **kwargs)
+
     return func_wrapper
 
 
@@ -17,8 +18,7 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
 
     @classmethod
     def setup_class(cls):
-        asks.init('trio')
-
+        multio.init('trio')
 
     @trio_run
     async def test_hsession_smallpool(self):
@@ -27,7 +27,6 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
         async with trio.open_nursery() as n:
             for _ in range(10):
                 n.start_soon(base_tests.hsession_t_smallpool, s)
-
 
     @trio_run
     async def test_session_stateful(self):
@@ -41,7 +40,6 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
         assert cookies[0].name == 'cow'
         assert cookies[0].value == 'moo'
 
-
     @trio_run
     async def test_session_stateful_double(self):
         from asks.sessions import Session
@@ -49,7 +47,6 @@ class TestAsksTrio(metaclass=base_tests.TestAsksMeta):
         async with trio.open_nursery() as n:
             for _ in range(4):
                 n.start_soon(base_tests.hsession_t_stateful, s)
-
 
     # Session Tests
     # ==============


### PR DESCRIPTION
This prevents some code duplication between libs that want to support
both trio and curio, with the compat code now shared between all of the
libraries.