### PR TITLE
Make StreamBody.close() use `_checked_out_sockets`

### DIFF
--- a/asks/response_objects.py
+++ b/asks/response_objects.py
@@ -180,7 +180,7 @@ class StreamBody:
         return self
 
     async def close(self):
-        if self.sock in self.session.checked_out_sockets:
+        if self.sock in self.session._checked_out_sockets:
             self.sock._active = False
             await self.session._replace_connection(self.sock)
 


### PR DESCRIPTION
StreamBody.close() is currently broken as it uses old `Session.checked_out_sockets` attribute which was replaced with `Session._checked_out_sockets` in commit a6e4b906a08b69cbad0bc130e85fb6cbb3a26602.

Update: the test that failed is a completely unrelated one.