### PR TITLE
Do not fail if a connection header is missing.

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -554,7 +554,7 @@ class Request:
                 if resp_data['headers']['transfer-encoding'] == 'chunked':
                     get_body = True
             except KeyError:
-                if resp_data['headers']['connection'].lower() == 'close':
+                if resp_data['headers'].get('connection', '').lower() == 'close':
                     get_body = True
 
         if get_body:


### PR DESCRIPTION
When writing a point to `InfluxDB`, I receive the following headers back:

```
{'encoding': 'utf-8', 'method': 'POST', 'status_code': 204, 'reason_phrase': 'No Content', 'http_version': '1.1', 'headers': {'content-type': 'application/json', 'request-id': '33f73462-2d31-11e8-8012-000000000000', 'x-influxdb-build': 'OSS', 'x-influxdb-version': 'v1.4.3', 'x-request-id': '33f73462-2d31-11e8-8012-000000000000', 'date': 'Wed, 21 Mar 2018 17:56:38 GMT'}, 'body': b'', 'url': 'http://localhost:8086/write?db=testdb'}
```

asks fails here, and raises a KeyError when it tries to access `headers['connection']`.