### PR TITLE
Timeout leak

### DIFF
--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -139,36 +139,42 @@ class BaseSession:
                 url = self._make_url() + path
 
             sock = await self._grab_connection(url)
-            port = sock.port
+            try:
+                port = sock.port
 
-            if self.headers is not None:
-                headers = copy(self.headers)
-                if req_headers is not None:
-                    headers.update(req_headers)
-                req_headers = headers
+                if self.headers is not None:
+                    headers = copy(self.headers)
+                    if req_headers is not None:
+                        headers.update(req_headers)
+                    req_headers = headers
 
-            req_obj = Request(self,
-                              method,
-                              url,
-                              port,
-                              headers=req_headers,
-                              encoding=self.encoding,
-                              sock=sock,
-                              persist_cookies=self._cookie_tracker_obj,
-                              **kwargs)
+                req_obj = Request(self,
+                                  method,
+                                  url,
+                                  port,
+                                  headers=req_headers,
+                                  encoding=self.encoding,
+                                  sock=sock,
+                                  persist_cookies=self._cookie_tracker_obj,
+                                  **kwargs)
 
-            if timeout is None:
-                sock, r = await req_obj.make_request()
-            else:
-                sock, r = await self.timeout_manager(timeout, req_obj)
+                if timeout is None:
+                    sock, r = await req_obj.make_request()
+                else:
+                    sock, r = await self.timeout_manager(timeout, req_obj)
 
-            if sock is not None:
-                try:
-                    if r.headers['connection'].lower() == 'close':
-                        sock._active = False
-                except KeyError:
-                    pass
-                await self._replace_connection(sock)
+                if sock is not None:
+                    try:
+                        if r.headers['connection'].lower() == 'close':
+                            sock._active = False
+                    except KeyError:
+                        pass
+
+            finally:
+                # Unless sock was set to None (streaming mode), put it back
+                # no matter the kind of error that happened.
+                if sock:
+                    await self._replace_connection(sock)
 
         return r
 


### PR DESCRIPTION
 You can make asks leak sockets in this way:

- Setup a HTTP server that never sends a responds, to simulate a timeout (like `nc -l` - except this one can only handle a single connection at a time, which can be an issue when trying to simulate this effect).

- Use this script:

```
url = "http://localhost:8080"

import trio
import asks
import multio
import asks.errors

multio.init('trio')


async def main():
    from asks import Session
    s = Session()
    
    while True:
            try:
                r = await s.get(url, timeout=2)
            except asks.errors.AsksException:
                print('timeout')
                continue
            print(r.status_code)
            await trio.sleep(0.5)

trio.run(main)
```

- Observe the files open:

```
$ lsof | grep python | grep TCP
```

The reason is that in the request  method, where _grab_connection is called to open a socket, timeout errors (and possibly others) are not handled:

https://github.com/theelous3/asks/blob/c0b7fb4dec18452c0f8c0028d0e892c27d6a2ea2/asks/sessions.py#L90

That is, if a socket or timeout error occurs (everything that is not protocol-level), the socket is never returned to the pool, or closed.

The right approach seems to me to be `try...finally` for the non-streaming case - after all, we'd really want to return the socket, regardless of the kind of exception. Say there is an internal KeyError inside asks; if the user for some reason catches that exception, we'd still do not want to leak sockets.

But this is brittle, because often the request itself returns the connection to the pool, and the control flow here is difficult (for me) to understand.

Intermission: Why does the request object replace the socket with it's own? It would seem to be that if I do a ssingle mple request, and `_get_new_sock` is called, for example because there was a Connection: close, asks would then actually do another reconnect to that host, and keeping it open, even though I might never to another request. I did not verify this, I am just reading the code.

So this code works, but I also had the following case. A request caused this:

```
Traceback (most recent call last):
  File "/Users/michael/.local/share/virtualenvs/-Ejy1jg8r/src/h11/h11/_state.py", line 249, in _fire_event_triggered_transitions
    new_state = EVENT_TRIGGERED_TRANSITIONS[role][state][event_type]
KeyError: <class 'h11._events.ConnectionClosed'>
```

(possibly another bug in asks).

This will cause asks to call `_get_new_sock`, because it is a ProtocolError. Which calls `_replace_connection` (all part of the code in request_object.py).

By the time the session code (this PR) wants to call `_replace_connection`,  the socket was already returned the pool, causing an exception. And now obvious way to detect this.


