### PR TITLE
Oon trio, we need to call sock.aclose.

### DIFF
--- a/asks/req_structs.py
+++ b/asks/req_structs.py
@@ -3,6 +3,7 @@
 Some structures used throughout asks.
 '''
 from collections import OrderedDict, MutableMapping, Mapping, deque
+from .utils import close_socket
 
 
 class SocketQ(deque):
@@ -26,7 +27,7 @@ class SocketQ(deque):
     async def free_pool(self):
         while self:
             sock = self.pop()
-            await sock.close()
+            await close_socket(sock)
 
     def __contains__(self, host_loc):
         for i in self:

--- a/asks/response_objects.py
+++ b/asks/response_objects.py
@@ -8,6 +8,7 @@ from async_generator import async_generator, yield_
 import h11
 
 from multio import asynclib
+from .utils import close_socket
 
 
 class Response:
@@ -180,7 +181,7 @@ class StreamBody:
         return self
 
     async def close(self):
-        await self.sock.close()
+        await close_socket(self.sock)
 
     async def __aexit__(self, *exc_info):
         await self.close()

--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -15,7 +15,7 @@ from .cookie_utils import CookieTracker
 from .errors import RequestTimeout, BadHttpResponse
 from .req_structs import SocketQ
 from .request_object import Request
-from .utils import get_netloc_port
+from .utils import get_netloc_port, close_socket
 
 __all__ = ['Session']
 
@@ -180,14 +180,14 @@ class BaseSession(metaclass=ABCMeta):
                 if sock is not None:
                     try:
                         if r.headers['connection'].lower() == 'close':
-                            await sock.close()
+                            await close_socket(sock)
                             sock._active = False
                     except KeyError:
                         pass
                     await self._replace_connection(sock)
 
             except RemoteProtocolError as e:
-                await sock.close()
+                await close_socket(sock)
                 sock._active = False
                 await self._replace_connection(sock)
                 raise BadHttpResponse('Invalid HTTP response from server.') from e

--- a/asks/utils.py
+++ b/asks/utils.py
@@ -62,3 +62,11 @@ def requote_uri(uri):
         # there may be unquoted '%'s in the URI. We need to make sure they're
         # properly quoted so they do not cause issues elsewhere.
         return quote(uri, safe=safe_without_percent)
+
+
+async def close_socket(sock):
+    try:
+        await sock.close()
+    except AttributeError:
+        # account for trio's name-things-whatever
+        await sock.aclose()


### PR DESCRIPTION
This was done in at least one case before, but that code was removed in 04b2d037130a1a6dc5e19766025c2e1c8ad5cf5b - not sure why, for me, on trio, it is still necessary.