### PR TITLE
Handle the case of the sock binding being not initialized.

### DIFF
--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -163,6 +163,7 @@ class BaseSession(metaclass=ABCMeta):
 
             retry = False
 
+            sock = None
             try:
                 sock = await self._grab_connection(url)
                 port = sock.port
@@ -202,7 +203,8 @@ class BaseSession(metaclass=ABCMeta):
                     raise e
 
             except Exception as e:
-                await self._handle_exception(e, sock)
+                if sock:
+                    await self._handle_exception(e, sock)
 
             # any BaseException is considered unlawful murder, and
             # Session.cleanup should be called to tidy up sockets.


### PR DESCRIPTION
If an exception occurs in `grab_connection`, `sock` is not set. Without this, I sometimes get `NameError`s.