### PR TITLE
Re-raise exceptions.

### DIFF
--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -203,6 +203,7 @@ class BaseSession(metaclass=ABCMeta):
             except Exception as e:
                 if sock:
                     await self._handle_exception(e, sock)
+                raise
 
             # any BaseException is considered unlawful murder, and
             # Session.cleanup should be called to tidy up sockets.


### PR DESCRIPTION
W/o this, I sometimes see the message `NameError: r is not defined`, because it just falls through.