### PR TITLE
include LICENCE.txt in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENCE.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENCE.txt


### PR DESCRIPTION
The MIT license requires that it be included with all copies of the software.