### PR TITLE
Add `status_code` attribute to BadStatus errors

### DIFF
--- a/asks/errors.py
+++ b/asks/errors.py
@@ -26,6 +26,9 @@ class BadHttpResponse(AsksException):
 
 
 class BadStatus(AsksException):
+    def __init__(self, err, status_code=500):
+        super().__init__(err)
+        self.status_code = status_code
     pass
 
 

--- a/asks/response_objects.py
+++ b/asks/response_objects.py
@@ -88,9 +88,9 @@ class Response(BaseResponse):
         Raise BadStatus if one occurred.
         '''
         if 400 <= self.status_code < 500:
-            raise BadStatus('{} Client Error: {} for url: {}'.format(self.status_code, self.reason_phrase, self.url))
+            raise BadStatus('{} Client Error: {} for url: {}'.format(self.status_code, self.reason_phrase, self.url), self.status_code)
         elif 500 <= self.status_code < 600:
-            raise BadStatus('{} Server Error: {} for url: {}'.format(self.status_code, self.reason_phrase, self.url))
+            raise BadStatus('{} Server Error: {} for url: {}'.format(self.status_code, self.reason_phrase, self.url), self.status_code)
 
     @property
     def text(self):

--- a/tests/test_curio.py
+++ b/tests/test_curio.py
@@ -50,6 +50,7 @@ async def test_http_get_client_error():
     with pytest.raises(BadStatus) as excinfo:
         r.raise_for_status()
     assert excinfo.match('400 Client Error: BAD REQUEST')
+    assert excinfo.value.status_code == 400
 
 
 @curio_run
@@ -58,6 +59,7 @@ async def test_http_get_server_error():
     with pytest.raises(BadStatus) as excinfo:
         r.raise_for_status()
     assert excinfo.match('500 Server Error: INTERNAL SERVER ERROR')
+    assert excinfo.value.status_code == 500
 
 
 # Redirect tests


### PR DESCRIPTION
BadStatus exceptions need the error code as number, not just at the beginning of their string repr.