### PR TITLE
Allow instantiating `asks.Session` outside of event loop

### DIFF
--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -315,10 +315,13 @@ class Session(BaseSession):
 
         self._conn_pool = SocketQ()
 
-        self._sema = create_semaphore(connections)
+        self._sema = None
+        self._connections = connections
 
     @property
     def sema(self):
+        if self._sema is None:
+            self._sema = create_semaphore(self._connections)
         return self._sema
 
     def _checkout_connection(self, host_loc):

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -251,6 +251,7 @@ async def test_session_stateful():
         await g.spawn(hsession_t_stateful, s)
     assert 'www.google.ie' in s._cookie_tracker.domain_dict.keys()
 
+
 async def session_t_stateful_double_worker(s):
     r = await s.get()
     assert r.status_code == 200
@@ -264,9 +265,6 @@ async def test_session_stateful_double():
         for _ in range(4):
             await g.spawn(session_t_stateful_double_worker, s)
 
-
-# Session Tests
-# ==============
 
 # Test Session with two pooled connections on four get requests.
 async def session_t_smallpool(s):

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -281,3 +281,11 @@ async def test_Session_smallpool():
     async with create_task_group() as g:
         for _ in range(10):
             await g.spawn(session_t_smallpool, s)
+
+
+def test_instantiate_session_outside_of_event_loop():
+    from asks.sessions import Session
+    try:
+        Session()
+    except RuntimeError:
+        pytest.fail("Could not instantiate Session outside of event loop")


### PR DESCRIPTION
Migration to `anyio` has broken `asks.Session` instantiation outside of running event loop. This merge request fixes it.