### PR TITLE
Verify keyword arguments in asks.Session.request

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -65,7 +65,7 @@ class RequestProcessor:
         callback (func): A callback function to be called on each bytechunk of
             of the response body.
 
-        stream (bool): Weather or not to return a StreamResponse vs Response
+        stream (bool): Whether or not to return a StreamResponse vs Response
 
         timeout (int or float): A numeric representation of the longest time to
             wait on a complete response once a request has been sent.

--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -88,7 +88,7 @@ class BaseSession(metaclass=ABCMeta):
         scheme, host, path, parameters, query, fragment = urlparse(
             host_loc)
         if parameters or query or fragment:
-            raise ValueError('Supplied info beyond scheme, host.' +
+            raise TypeError('Supplied info beyond scheme, host.' +
                              ' Host should be top level only: ', path)
 
         host, port = get_netloc_port(scheme, host)
@@ -167,9 +167,11 @@ class BaseSession(metaclass=ABCMeta):
             "stream",
         }
 
-        unknown_kwargs = set(kwargs.keys()) - ALLOWED_KWARGS
-        if unknown_kwargs:
-            raise ValueError("Unknown keyword arguments", unknown_kwargs)
+        unknown_kwarg = \
+            next((k for k in kwargs if k not in ALLOWED_KWARGS), None)
+        if unknown_kwarg is not None:
+            raise TypeError("request() got an unexpected keyword argument " +
+                            repr(unknown_kwarg))
 
         timeout = kwargs.get('timeout', None)
         req_headers = kwargs.pop('headers', None)

--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -167,11 +167,11 @@ class BaseSession(metaclass=ABCMeta):
             "stream",
         }
 
-        unknown_kwarg = \
-            next((k for k in kwargs if k not in ALLOWED_KWARGS), None)
-        if unknown_kwarg is not None:
+        try:
+            unknown_kwarg = next(k for k in kwargs if k not in ALLOWED_KWARGS)
+        except StopIteration:
             raise TypeError("request() got an unexpected keyword argument " +
-                            repr(unknown_kwarg))
+                            repr(unknown_kwarg)) from None
 
         timeout = kwargs.get('timeout', None)
         req_headers = kwargs.pop('headers', None)

--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -142,11 +142,35 @@ class BaseSession(metaclass=ABCMeta):
                             domains.
                         auth (child of AuthBase): An object for handling auth
                             construction.
+                        stream (bool): Whether or not to return a StreamResponse
+                            vs Response
 
         When you call something like Session.get() or asks.post(), you're
         really calling a partial method that has the 'method' argument
         pre-completed.
         '''
+
+        ALLOWED_KWARGS = {
+            "data",
+            "params",
+            "headers",
+            "encoding",
+            "json",
+            "files",
+            "cookies",
+            "callback",
+            "timeout",
+            "retries",
+            "max_redirects",
+            "persist_cookies",
+            "auth",
+            "stream",
+        }
+
+        unknown_kwargs = set(kwargs.keys()) - ALLOWED_KWARGS
+        if unknown_kwargs:
+            raise ValueError("Unknown keyword arguments", unknown_kwargs)
+
         timeout = kwargs.get('timeout', None)
         req_headers = kwargs.pop('headers', None)
 

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -67,9 +67,17 @@ async def test_https_get(server):
 @Server(_TEST_LOC, steps=[send_200, finish], socket_wrapper=ssl_socket_wrapper)
 @curio_run
 async def test_https_get_checks_cert(server):
+    try:
+        expected_error = ssl.SSLCertVerificationError
+    except AttributeError:
+        # If we're running in Python <3.7, we won't have the specific error
+        # that will be raised, but we can expect it to raise an SSLError
+        # nonetheless
+        expected_error = ssl.SSLError
+
     # The server's certificate isn't signed by any real CA. By default, asks
     # should notice that, and raise an error.
-    with pytest.raises(ssl.SSLCertVerificationError):
+    with pytest.raises(expected_error):
         await asks.get(server.https_test_url)
 
 

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -432,3 +432,14 @@ def test_instantiate_session_outside_of_event_loop():
         asks.Session()
     except RuntimeError:
         pytest.fail("Could not instantiate Session outside of event loop")
+
+
+@curio_run
+async def test_session_unknown_kwargs():
+    session = asks.Session("https://httpbin.org/get")
+    try:
+        await session.request("GET", foo=0, bar=3, shite=3)
+    except ValueError as e:
+        assert e.args == ("Unknown keyword arguments", {"foo", "bar", "shite"})
+    else:
+        pytest.fail("Passing unknown keyword arguments does not raise ValueError")

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -451,4 +451,4 @@ async def test_session_unknown_kwargs():
         # yes, i chose "ko" to make the line 79 characters :D
         assert e.args == ("request() got an unexpected keyword argument 'ko'",)
     else:
-        pytest.fail("Passing unknown keyword arguments does not any TypeError")
+        pytest.fail("Passing unknown kwargs does not raise TypeError")

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -446,8 +446,9 @@ def test_instantiate_session_outside_of_event_loop():
 async def test_session_unknown_kwargs():
     session = asks.Session("https://httpbin.org/get")
     try:
-        await session.request("GET", foo=0, bar=3, shite=3)
-    except ValueError as e:
-        assert e.args == ("Unknown keyword arguments", {"foo", "bar", "shite"})
+        await session.request("GET", ko=7, foo=0, bar=3, shite=3)
+    except TypeError as e:
+        # yes, i chose "ko" to make the line 79 characters :D
+        assert e.args == ("request() got an unexpected keyword argument 'ko'",)
     else:
-        pytest.fail("Passing unknown keyword arguments does not raise ValueError")
+        pytest.fail("Passing unknown keyword arguments does not any TypeError")


### PR DESCRIPTION
Addresses https://github.com/theelous3/asks/issues/141, raising a ValueError if any currently-unknown keyword arguments are passed into `asks.Session.request`.

I also fixed one test in python versions less than 3.7, which do not have `SSLCertVerificationError`.