### PR TITLE
Fixed unknown_kwarg check

### DIFF
--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -171,7 +171,7 @@ class BaseSession(metaclass=ABCMeta):
         unknown_kwarg = next((k for k in kwargs if k not in ALLOWED_KWARGS), sentinel)
         # if `unknown_kwargs` is not `sentinel`, the some unkown kwargs are in `kwargs`
         # and hence we should raise a TypeError
-        if unknown_kwargs is not sentinel:
+        if unknown_kwarg is not sentinel:
             raise TypeError("request() got an unexpected keyword argument{!r}".format(unknown_kwarg)) from None
 
         timeout = kwargs.get('timeout', None)

--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -167,11 +167,12 @@ class BaseSession(metaclass=ABCMeta):
             "stream",
         }
 
-        try:
-            unknown_kwarg = next(k for k in kwargs if k not in ALLOWED_KWARGS)
-        except StopIteration:
-            raise TypeError("request() got an unexpected keyword argument " +
-                            repr(unknown_kwarg)) from None
+        sentinel = object() 
+        unknown_kwarg = next((k for k in kwargs if k not in ALLOWED_KWARGS), sentinel)
+        # if `unknown_kwargs` is not `sentinel`, the some unkown kwargs are in `kwargs`
+        # and hence we should raise a TypeError
+        if unknown_kwargs is not sentinel:
+            raise TypeError("request() got an unexpected keyword argument{!r}".format(unknown_kwarg)) from None
 
         timeout = kwargs.get('timeout', None)
         req_headers = kwargs.pop('headers', None)


### PR DESCRIPTION
The current implementation seems to be not raising a `TypError` if an unknown keyword arguments is passed in the request. And also, it will raise a `NameError`, if not kwarg is passed, since the `unknown_kwarg` is being again used while handling the `StopIteration` exception.