### PR TITLE
Fix redirection bug where Location header contains a relative URL

### DIFF
--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -159,6 +159,25 @@ async def test_http_max_redirect_error(server):
     max_requests=2,
     steps=[
         [
+            (HttpMethods.GET, "/path/redirect"),
+            partial(send_303, headers=[("location", "../foo/bar")]),
+            finish,
+        ],
+        [(HttpMethods.GET, "/foo/bar"), send_200, finish],
+    ],
+)
+@curio_run
+async def test_redirect_relative_url(server):
+    r = await asks.get(server.http_test_url + "/path/redirect", max_redirects=1)
+    assert len(r.history) == 1
+    assert r.url == "http://{0}:{1}/foo/bar".format(*_TEST_LOC)
+
+
+@Server(
+    _TEST_LOC,
+    max_requests=2,
+    steps=[
+        [
             (HttpMethods.GET, "/redirect_once"),
             partial(send_303, headers=[("location", "/")]),
             finish,


### PR DESCRIPTION
This fixes #131.  This fixes a bug that if `Location` header has a relative URL which consists of `.` or `..` redirection is mishandled.  I also added a test case to reproduce the bug.

Also there was a bug that `UnboundLocalError` had risen when `Session.request()` method got unknown keyword arguments, so I fixed this as well.  I believe this bug was made at 32fcedcd7d0019007d50d4e18268b340f5776c72.