### PR TITLE
Currently supports trio's development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Above you'll find detailed docs with a large number of simple examples to help y
 
 `pip install asks`
 
-Note: Currently supports `trio`'s development branch. You can install this by doing `pip install git+https://github.com/python-trio/trio.git`
-
 
 ## Examples
 


### PR DESCRIPTION
The README says:

> Note: Currently supports trio's development branch. You can install this by doing pip install git+https://github.com/python-trio/trio.git

Is that still true? That was written two years ago and trio has had many releases since then. 