### PR TITLE
When encoding URLs, don't encode elements of iterables twice

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -440,9 +440,8 @@ class RequestProcessor:
                     query.append('='.join(quote_plus(x) for x in (k, key)))
             elif hasattr(v, '__iter__'):
                 for elm in v:
-                    query.append('='.join(quote_plus(x) for x in (k,
-                                 quote_plus('+'.join(str(elm).split())))))
-
+                    elm_quoted = "+".join(quote_plus(str(y)) for y in elm.split())
+                    query.append("=".join((quote_plus(k), elm_quoted)))
         if params and query:
             if not base_query:
                 return requote_uri('?' + '&'.join(query))

--- a/tests/test_request_object.py
+++ b/tests/test_request_object.py
@@ -40,6 +40,8 @@ def test_http1_0(monkeypatch):
     [{'zero': 0}, '?zero=0'],
     [{'empty': ''}, '?empty='],
     [{'false': False}, '?false=False'],
+    [{'foo': 'abc', 'bar': 'jkl'}, '?foo=abc&bar=jkl'],
+    [{'foo': ['abc def', 'ghi'], 'bar baz': 'jkl'}, '?foo=abc+def&foo=ghi&bar+baz=jkl'],
 ])
 def test_dict_to_query(data, query_str):
     assert RequestProcessor._dict_to_query(data) == query_str


### PR DESCRIPTION
Formerly, the code would run each element through `quote_plus` twice:
```
import asks
test_data = [{'foo': 'abc', 'bar': 'jkl'}, {'foo': ['abc def', 'ghi'], 'bar baz': 'jkl'}]

for row in test_data:
    print(asks.request_object.RequestProcessor._dict_to_query(row))
```
```
?foo=abc&bar=jkl
?foo=abc%252Bdef&foo=ghi&bar+baz=jkl
```

Note that `%252B` is `+` encoded twice:
```
>>> from urllib.parse import quote_plus
>>> quote_plus('+')
'%2B'
>>> quote_plus('%2B')
'%252B'
```

This pull request makes it so that each element is only encoded once.