### PR TITLE
Ensure that ipv6 addresses are handled correctly.

### DIFF
--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -89,7 +89,8 @@ class BaseSession(metaclass=ABCMeta):
         Simple enough stuff to figure out where we should connect, and creates
         the appropriate connection.
         """
-        scheme, host, path, parameters, query, fragment = urlparse(host_loc)
+        parsed_hostloc = urlparse(host_loc)
+        scheme, host, path, parameters, query, fragment = parsed_hostloc
         if parameters or query or fragment:
             raise TypeError(
                 "Supplied info beyond scheme, host."
@@ -97,8 +98,7 @@ class BaseSession(metaclass=ABCMeta):
                 path,
             )
 
-        host, port = get_netloc_port(scheme, host)
-
+        host, port = get_netloc_port(parsed_hostloc)
         if scheme == "http":
             return await self._open_connection_http((host, int(port))), port
         else:

--- a/asks/utils.py
+++ b/asks/utils.py
@@ -17,18 +17,14 @@ async def timeout_manager(timeout, coro, *args):
         raise RequestTimeout from e
 
 
-def get_netloc_port(scheme, netloc):
-    try:
-        netloc, port = netloc.split(':')
-    except ValueError:
-        if scheme == 'https':
+def get_netloc_port(parsed_url):
+    port = parsed_url.port
+    if not port:
+        if parsed_url.scheme == 'https':
             port = '443'
         else:
             port = '80'
-    except TypeError:
-        raise RuntimeError('Something is goofed. Contact the author!')
-    return netloc, port
-
+    return parsed_url.hostname, str(port)
 
 # The unreserved URI characters (RFC 3986)
 UNRESERVED_SET = ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+# pylint: disable=no-member
+
+from urllib.parse import urlparse
+
+from asks.utils import get_netloc_port
+
+def test_netloc_port():
+    assert ('example.com', '80') == get_netloc_port(urlparse('http://example.com'))
+    assert ('example.com', '443') == get_netloc_port(urlparse('http://example.com:443'))
+    assert ('example.com', '443') == get_netloc_port(urlparse('https://example.com'))
+    assert ('example.com', '1234') == get_netloc_port(urlparse('https://example.com:1234'))
+
+    ipv4addr = '10.0.0.1'
+    assert (ipv4addr, '80') == get_netloc_port(urlparse('http://{}'.format(ipv4addr)))
+    assert (ipv4addr, '443') == get_netloc_port(urlparse('https://{}'.format(ipv4addr)))
+    assert (ipv4addr, '1234') == get_netloc_port(urlparse('http://{}:1234'.format(ipv4addr)))
+    assert (ipv4addr, '1234') == get_netloc_port(urlparse('https://{}:1234'.format(ipv4addr)))
+
+    ipv6addr = 'aaaa:bbbb:cccc:dddd:eeee:ffff:1111:2222'
+    assert (ipv6addr, '80') == get_netloc_port(urlparse('http://[{}]'.format(ipv6addr)))
+    assert (ipv6addr, '443') == get_netloc_port(urlparse('https://[{}]'.format(ipv6addr)))
+    assert (ipv6addr, '1234') == get_netloc_port(urlparse('http://[{}]:1234'.format(ipv6addr)))
+    assert (ipv6addr, '1234') == get_netloc_port(urlparse('https://[{}]:1234'.format(ipv6addr)))


### PR DESCRIPTION
Use hostname and port from the parsed url instead of splitting host on :,
since that is a valid character in an ipv6 address.