### PR TITLE
New multipart API

### DIFF
--- a/asks/base_funcs.py
+++ b/asks/base_funcs.py
@@ -5,7 +5,7 @@ to the caller.
 '''
 from functools import partial
 
-from asks.sessions import Session
+from .sessions import Session
 
 
 __all__ = ['get', 'head', 'post', 'put', 'delete', 'options', 'patch', 'request']

--- a/asks/multipart.py
+++ b/asks/multipart.py
@@ -1,0 +1,146 @@
+import mimetypes
+
+from typing import BinaryIO, NamedTuple, Union, Optional
+from pathlib import Path
+
+from anyio import aopen, AsyncFile
+
+
+_RAW_BYTES_MIMETYPE = 'application/octet-stream'
+
+
+class MultipartData(NamedTuple):
+    '''
+    Describes data to be sent in a multipart/form-data.
+
+    This should be used for manually specifying the mimetype or the basename of
+    a field to be sent, and/or to send raw bytes as files.
+    '''
+    binary_source: Union[Path, bytes, BinaryIO, AsyncFile]
+    mime_type: Optional[str] = _RAW_BYTES_MIMETYPE
+    basename: Optional[str] = None
+
+    async def to_bytes(self):
+        binary_source = self.binary_source
+
+        if isinstance(binary_source, Path):
+            async with await aopen(binary_source, 'rb') as f:
+                return await f.read()
+
+        if isinstance(binary_source, bytes):
+            return binary_source
+
+        # else we should have a BinaryIO or an async equivalent,
+        # which we can't really type-check at runtime
+        result = binary_source.read()
+
+        if isinstance(result, bytes):
+            return result
+
+        # We must then assume it is a coroutine.
+        return await result
+
+
+def _to_multipart_file(value):
+    '''
+    Ensure a file-like supported type is encapsulated in a MultipartData object.
+
+    Args:
+        value: One of the supported file-like types.
+        encoding: The desired encoding to send a field as.
+
+    Returns:
+        MultipartData: An object describing a multipart/form-data file field.
+    '''
+
+    basename = Path(value.name).name if hasattr(value, 'name') else None
+    mime_type = (
+        mimetypes.guess_type(basename)[0]
+        if basename is not None
+        else _RAW_BYTES_MIMETYPE
+    )
+
+    return MultipartData(
+        binary_source=value,
+        mime_type=mime_type,
+        basename=basename,
+    )
+
+
+def _to_multipart_form_data(value, encoding):
+    '''
+    Transform a form-data entry into a MultipartData object.
+
+    If `value` is one of the supported file-like types, it will be seen as a
+    file.  Else it will be converted into a string and sent as raw form data.
+
+    Args:
+        value: A form value to encode or a file-like supported object.
+        encoding: The desired encoding to send a field as.
+
+    Returns:
+        MultipartData: An object describing a multipart/form-data field.
+    '''
+    if isinstance(value, MultipartData):
+        return value
+
+    if isinstance(value, (Path, bytes)) or hasattr(value, 'read'):
+        return _to_multipart_file(value)
+
+    # It's not a supported file type, so we do our best to transform it into form data.
+    return MultipartData(
+        binary_source=str(value).encode(encoding),
+        mime_type=None,
+        basename=None,
+    )
+
+
+async def build_multipart_body(values, encoding, boundary_data):
+    '''
+    Forms a multipart request body from  a dict of form fields to values.
+
+    Args:
+        values: A dict of strings (field names) to:
+                    - Path
+                    - IO[bytes]
+                    - An async file-like object (read() is async), opened in binary mode.
+                    - bytes
+                    - MultipartData
+                    - Any other value that can be sent by being converted to str.
+                The first four will be sent as files. MultipartData will be sent
+                as a file if it has the necessary info to do so. The rest will be
+                sent as ordinary data.
+
+    Returns:
+        multipart_body (bytes): The strings representation of the content body,
+                                multipart formatted.
+    '''
+    boundary = b''.join((b'--', bytes(boundary_data, encoding)))
+
+    multipart_body = b''
+
+    for k, v in values.items():
+        multipart_data = _to_multipart_form_data(v, encoding)
+
+        multipart_body += b''.join((
+            boundary,
+            b'\r\n',
+            'Content-Disposition: form-data; name="{}"'.format(k).encode(encoding),
+            (
+                b''
+                if multipart_data.basename is None
+                else '; filename="{}"'.format(multipart_data.basename).encode(encoding)
+            ),
+            (
+                b''
+                if multipart_data.mime_type is None
+                else '; Content-Type: {}'.format(multipart_data.mime_type).encode(encoding)
+            ),
+            b'\r\n\r\n',
+            await multipart_data.to_bytes(),
+            b'\r\n',
+        ))
+
+    multipart_body += boundary + b'--\r\n'
+
+    return multipart_body

--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -17,6 +17,7 @@ from .req_structs import SocketQ
 from .request_object import RequestProcessor
 from .utils import get_netloc_port, timeout_manager
 
+
 __all__ = ["Session"]
 
 
@@ -130,6 +131,8 @@ class BaseSession(metaclass=ABCMeta):
                             the request body.
                         files (dict): A dict of `filename:filepath`s to be sent
                             as multipart.
+                        multipart (dict): Data (files or form data) to be sent as a
+                            multipart form.
                         cookies (dict): A dict of `name:value` cookies to be
                             passed in request.
                         callback (func): A callback function to be called on
@@ -162,6 +165,7 @@ class BaseSession(metaclass=ABCMeta):
             "encoding",
             "json",
             "files",
+            "multipart",
             "cookies",
             "callback",
             "timeout",

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,0 +1,155 @@
+"""Tests for the generation of multipart/form-data request bodies."""
+from collections import OrderedDict
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+
+import pytest
+
+from anyio import aopen
+from asks.multipart import build_multipart_body, MultipartData
+
+TEST_DIR = Path(__file__).absolute().parent
+
+
+@pytest.fixture
+def mock_aopen():
+    async def mock_aopen(*args, **kwargs):
+        class FakeAsyncFile:
+            async def read(self):
+                return b'dummyfile\n'
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args, **kwargs):
+                pass
+
+            name = 'test.txt'
+
+        return FakeAsyncFile()
+
+    with patch('asks.multipart.aopen', mock_aopen):
+        yield mock_aopen
+
+
+@pytest.mark.curio
+async def test_multipart_body_dummy_file():
+    assert await build_multipart_body(
+        values=OrderedDict({
+            'file': MultipartData(
+                b'dummyfile\n',
+                mime_type='text/plain',
+                basename='test.txt'
+            ),
+        }),
+        encoding='utf8',
+        boundary_data='8banana133744910kmmr13a56!102!5649',
+    ) == b'--8banana133744910kmmr13a56!102!5649\r\nContent-Disposition: form-data; name="file"; filename="test.txt"; Content-Type: text/plain\r\n\r\ndummyfile\n\r\n--8banana133744910kmmr13a56!102!5649--\r\n'
+
+
+@pytest.mark.curio
+async def test_multipart_body_with_not_file_argument():
+    assert await build_multipart_body(
+        values=OrderedDict({
+            'file': MultipartData(
+                b'dummyfile\n',
+                mime_type='text/plain',
+                basename='test.txt'
+            ),
+            'notfile': 'abc',
+        }),
+        encoding='utf8',
+        boundary_data='8banana133744910kmmr13a56!102!8423',
+    ) == b'--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="file"; filename="test.txt"; Content-Type: text/plain\r\n\r\ndummyfile\n\r\n--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="notfile"\r\n\r\nabc\r\n--8banana133744910kmmr13a56!102!8423--\r\n'
+
+
+@pytest.mark.curio
+async def test_multipart_body_with_file_like_argument():
+    # Simulate an open file with a BytesIO.
+    f = BytesIO(b'dummyfile\n')
+    f.name = 'test.txt'
+
+    assert await build_multipart_body(
+        values=OrderedDict({
+            'file': f,
+            'notfile': 'abc',
+        }),
+        encoding='utf8',
+        boundary_data='8banana133744910kmmr13a56!102!8423',
+    ) == b'--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="file"; filename="test.txt"; Content-Type: text/plain\r\n\r\ndummyfile\n\r\n--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="notfile"\r\n\r\nabc\r\n--8banana133744910kmmr13a56!102!8423--\r\n'
+
+
+@pytest.mark.curio
+async def test_multipart_body_with_path_argument(mock_aopen):
+    assert await build_multipart_body(
+        values=OrderedDict({
+            'file': Path('test.txt'),
+            'notfile': 'abc',
+        }),
+        encoding='utf8',
+        boundary_data='8banana133744910kmmr13a56!102!8423',
+    ) == b'--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="file"; filename="test.txt"; Content-Type: text/plain\r\n\r\ndummyfile\n\r\n--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="notfile"\r\n\r\nabc\r\n--8banana133744910kmmr13a56!102!8423--\r\n'
+
+
+
+@pytest.mark.curio
+async def test_multipart_body_with_multiple_arguments(mock_aopen):
+    # Simulate an open file with a BytesIO.
+    f = BytesIO(b'dummyfile2\n')
+    f.name = 'test.jpg'
+
+    assert await build_multipart_body(
+        values=OrderedDict({
+            'file': Path('test.txt'),
+            'file2': f,
+            'notfile': 'abc',
+            'integer': 3,
+        }),
+        encoding='utf8',
+        boundary_data='8banana133744910kmmr13a56!102!8423',
+    ) == b'--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="file"; filename="test.txt"; Content-Type: text/plain\r\n\r\ndummyfile\n\r\n--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="file2"; filename="test.jpg"; Content-Type: image/jpeg\r\n\r\ndummyfile2\n\r\n--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="notfile"\r\n\r\nabc\r\n--8banana133744910kmmr13a56!102!8423\r\nContent-Disposition: form-data; name="integer"\r\n\r\n3\r\n--8banana133744910kmmr13a56!102!8423--\r\n'
+
+
+@pytest.mark.curio
+async def test_multipart_body_with_custom_metadata(mock_aopen):
+    # Simulate an open file with a BytesIO.
+    f = BytesIO(b'dummyfile but it is a jpeg\n')
+    f.name = 'test.jpg'
+
+    assert await build_multipart_body(
+        values=OrderedDict({
+            'file': MultipartData(
+                f,
+                mime_type='text/plain',
+                basename='test.txt'
+            ),
+        }),
+        encoding='utf8',
+        boundary_data='8banana133744910kmmr13a56!102!5649',
+    ) == b'--8banana133744910kmmr13a56!102!5649\r\nContent-Disposition: form-data; name="file"; filename="test.txt"; Content-Type: text/plain\r\n\r\ndummyfile but it is a jpeg\n\r\n--8banana133744910kmmr13a56!102!5649--\r\n'
+
+
+@pytest.mark.curio
+async def test_multipart_body_with_real_test_file():
+    assert await build_multipart_body(
+        values=OrderedDict({
+            'file': TEST_DIR / 'test_multipart.txt',
+        }),
+        encoding='utf8',
+        boundary_data='8banana133744910kmmr13a56!102!5649',
+    ) == b'--8banana133744910kmmr13a56!102!5649\r\nContent-Disposition: form-data; name="file"; filename="test_multipart.txt"; Content-Type: text/plain\r\n\r\ndummyfile\n\r\n--8banana133744910kmmr13a56!102!5649--\r\n'
+
+
+@pytest.mark.curio
+async def test_multipart_body_with_real_pre_opened_test_file():
+    async with await aopen(TEST_DIR / 'test_multipart.txt', 'rb') as f:
+        print(type(f))
+
+        assert await build_multipart_body(
+            values=OrderedDict({
+                'file': f,
+            }),
+            encoding='utf8',
+            boundary_data='8banana133744910kmmr13a56!102!5649',
+        ) == b'--8banana133744910kmmr13a56!102!5649\r\nContent-Disposition: form-data; name="file"; filename="test_multipart.txt"; Content-Type: text/plain\r\n\r\ndummyfile\n\r\n--8banana133744910kmmr13a56!102!5649--\r\n'

--- a/tests/test_multipart.txt
+++ b/tests/test_multipart.txt
@@ -1,1 +1,0 @@
-dummyfile

--- a/tests/test_multipart.txt
+++ b/tests/test_multipart.txt
@@ -1,0 +1,1 @@
+dummyfile


### PR DESCRIPTION
My implementation of a proposal for #164.

- Keeps the current `files` API as is to avoid breakage.
- Adds a new `multipart` kwarg on `Session.request`.
- This kwarg is a dict as `files` is, but its values should be either:
    - A pathlib.Path file for opening a file for sending.
    - A file-like or async file-like (must provide `read()`, may provide `name`).
    - A bytes object (will be sent as raw data, `application/octet-stream`, with no filename).
    - An `asks.multipart.MultipartData` namedtuple, which must contain one of the above, a custom mime-type and a custom filename (for overriding any of those).
    - Anything else is simply converted to a string, encoded to the session encoding and sent as form data.
- Provides tests. Everything that was changed has been covered (checked locally with `pytest-cov`).

Test data was obtained by printing what was generated by the `files=` API to a log.

Implementation is fairly straightforward, code for building the request code has its behaviour based on the previous code. My intention here is mostly providing a new API to build upon.

Also, it now occurs to me that while I've tried to keep everything 3.5 compatible, `typing.NamedTuple` isn't. I'm open to change that for a simpler class if support for 3.5 should be kept.