### PR TITLE
Add an option for not following redirects

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -72,6 +72,9 @@ class RequestProcessor:
 
         max_redirects (int): The maximum number of redirects allowed.
 
+        follow_redirects (bool): Whether to follow redirects or return raw 3xx
+            responses.
+
         persist_cookies (True or None): Passing True instantiates a
             CookieTracker object to manage the return of cookies to the server
             under the relevant domains.
@@ -99,6 +102,7 @@ class RequestProcessor:
         self.stream = None
         self.timeout = None
         self.max_redirects = 20
+        self.follow_redirects = True
         self.sock = None
         self.persist_cookies = None
         self.mimetype = None
@@ -270,7 +274,8 @@ class RequestProcessor:
         if self.method != 'HEAD':
             if self.max_redirects < 0:
                 raise TooManyRedirects
-            response_obj = await self._redirect(response_obj)
+            if self.follow_redirects:
+                response_obj = await self._redirect(response_obj)
         response_obj.history = self.history_objects
 
         return response_obj

--- a/asks/sessions.py
+++ b/asks/sessions.py
@@ -141,6 +141,8 @@ class BaseSession(metaclass=ABCMeta):
                             connection errors.
                         max_redirects (int): The maximum number of redirects
                             allowed.
+                        follow_redirects (bool): Whether to follow redirects
+                            or return raw 3xx responses.
                         persist_cookies (True or None): Passing True
                             instantiates a CookieTracker object to manage the
                             return of cookies to the server under the relevant
@@ -167,6 +169,7 @@ class BaseSession(metaclass=ABCMeta):
             "timeout",
             "retries",
             "max_redirects",
+            "follow_redirects",
             "persist_cookies",
             "auth",
             "stream",

--- a/docs/source/overview-of-funcs-and-args.rst
+++ b/docs/source/overview-of-funcs-and-args.rst
@@ -154,6 +154,14 @@ You can limit the number of redirects by setting ``max_redirects``. By default, 
         r = await asks.get('www.httpbin.org/redirect/3', max_redirects=2)
 
 
+Preventing Redirects
+____________________
+
+You can prevent ``asks`` from automatically following redirects by setting ``follow_redirects`` to ``False``. By default, ``asks`` will automatically follow redirects until a non-redirect response or ``max_redirects`` are encountered. ::
+
+    async def example():
+        r = await asks.get('www.httpbin.org/redirect/3', follow_redirects=False)
+
 Set Timeout(s)
 ______________
 

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -190,6 +190,22 @@ async def test_http_under_max_redirect(server):
     r = await asks.get(server.http_test_url + "/redirect_once", max_redirects=2)
     assert r.status_code == 200
 
+@Server(
+    _TEST_LOC,
+    max_requests=1,
+    steps=[
+        [
+            (HttpMethods.GET, "/redirect_once"),
+            partial(send_303, headers=[("location", "/")]),
+            finish,
+        ],
+    ],
+)
+@curio_run
+async def test_dont_follow_redirects(server):
+    r = await asks.get(server.http_test_url + "/redirect_once", follow_redirects=False)
+    assert r.status_code == 303
+    assert r.headers["location"] == "/"
 
 # Timeout tests
 


### PR DESCRIPTION
Adds a new parameter `follow_redirects` which can be set to `False`
to turn off automatic redirect following, so that the original 3xx response
is returned. This allows the user to implement their own redirect logic - for
example to inspect the Location header before following a redirect.

Default value is `True` which preserves the existing behavior.