### PR TITLE
Don't require Content-Length header if response is HTTP/1.0

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -597,7 +597,9 @@ class RequestProcessor:
                 if "chunked" in resp_data["headers"]["transfer-encoding"].lower():
                     get_body = True
             except KeyError:
-                if resp_data["headers"].get("connection", "").lower() == "close":
+                connection_close = resp_data["headers"].get("connection", "").lower() == "close"
+                http_1 = response.http_version == b"1.0"
+                if connection_close or http_1:
                     get_body = True
 
         if get_body:

--- a/tests/test_request_object.py
+++ b/tests/test_request_object.py
@@ -6,10 +6,10 @@ import pytest
 from asks.request_object import RequestProcessor
 
 
-def _catch_response(monkeypatch, headers, data):
+def _catch_response(monkeypatch, headers, data, http_version=b"1.1"):
     req = RequestProcessor(None, "get", "toot-toot", None)
     events = [
-        h11._events.Response(status_code=200, headers=headers),
+        h11._events.Response(status_code=200, headers=headers, http_version=http_version),
         h11._events.Data(data=data),
         h11._events.EndOfMessage(),
     ]
@@ -32,8 +32,12 @@ def test_http1_1(monkeypatch):
     assert response.body == b"hello"
 
 
-def test_http1_0(monkeypatch):
+def test_http1_1_connection_close(monkeypatch):
     response = _catch_response(monkeypatch, [("Connection", "close")], b"hello")
+    assert response.body == b"hello"
+
+def test_http1_0_no_content_length(monkeypatch):
+    response = _catch_response(monkeypatch, [], b"hello", b"1.0")
     assert response.body == b"hello"
 
 


### PR DESCRIPTION
HTTP/1.0 responses do not require a Content-Length header; see here:
https://tools.ietf.org/html/rfc1945#section-7.2.2 (content length is implicitly
defined by the closing of the connection)

Therefore if no Content-Length is present, and the response version is 1.0,
read the response body.

Fixes #159