### PR TITLE
close socket after sending request with `connection: close` header

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -244,6 +244,11 @@ class RequestProcessor:
         if self.streaming:
             return None, response_obj
 
+        if 'connection' in asks_headers and asks_headers['connection'] == 'close' and self.sock._active:
+            self.sock._active = False
+            await self.sock.close()
+            return None, response_obj
+
         return self.sock, response_obj
 
     async def _request_io(self, h11_request, h11_body, h11_connection):


### PR DESCRIPTION
Currently when 'asks' uses a session without `connection: keep-alive` it
relies on the server to send the header `connection: close` back. So
even if 'asks' itself asks the server to close the connection it will
try to reuse the connection in the session unless the server sends that
header back. This is incorrect since it says in the official W3 standard

https://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html
Once a close has been signaled, the client MUST NOT send any more
requests on that connection.

So 'asks' should close the socket after receiving a response.