### PR TITLE
Use a bytearray object instead of bytes for reading response (-> quadratic to linear complexity for large responses)

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -575,7 +575,7 @@ class RequestProcessor:
                     for name, value in response.headers
                 ]
             ),
-            "body": b"",
+            "body": bytearray(),
             "url": self.req_url,
         }
 


### PR DESCRIPTION
I noticed that when reading large responses (without using streaming), asks could spend half an hour of CPU stuck in a loop while not doing anything.

After profiling is seems like the time is spent in _catch_response. And the code is concatenating bytes() together repeatedly. As bytes are not mutable python has to make a new copy of the whole response every time we concatenate a bit more data. As the response grows it does it over and over and eats all CPU.

Storing the response in a mutable bytearray() type completely removed that bottleneck and made everything instantaneous.

I didn't test this as the test suite seems to fail completely (in curio, "TypeError: spawn() got an unexpected keyword argument 'report_crash'"). How should I test ?