### PR TITLE
Fix EndOfStream handing issue introduced by Anyio2

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -16,7 +16,7 @@ from random import randint
 import mimetypes
 import re
 
-from anyio import open_file
+from anyio import open_file, EndOfStream
 import h11
 
 from .utils import requote_uri
@@ -653,7 +653,11 @@ class RequestProcessor:
         while True:
             event = h11_connection.next_event()
             if event is h11.NEED_DATA:
-                h11_connection.receive_data(await self.sock.receive())
+                try:
+                    data = await self.sock.receive()
+                except EndOfStream:
+                    data = b""
+                h11_connection.receive_data(data)
                 continue
             return event
 


### PR DESCRIPTION
The warning box in [AnyIO manual](https://anyio.readthedocs.io/en/stable/networking.html) states:

> Unlike the standard BSD sockets interface and most other networking
libraries, AnyIO (from 2.0 onwards) signals the end of any stream by
raising the `EndOfStream` exception instead of returning an empty bytes
object.