### PR TITLE
Remove references to deprecated init function

### DIFF
--- a/docs/source/a-look-at-sessions.rst
+++ b/docs/source/a-look-at-sessions.rst
@@ -33,7 +33,6 @@ The ``Session``'s ``connections`` argument dictates the maximum number of concur
 
     import asks
     import curio
-    asks.init('curio')
 
     a_list_of_many_urls = ['wow', 'so', 'many', 'urls']
 
@@ -94,7 +93,6 @@ Please don't actually do this or the http://jsontest.com website will be very un
 
     import asks
     import curio
-    asks.init('curio')
 
     async def worker(s, num):
         r = await s.get(path='/' + str(num))

--- a/docs/source/idioms.rst
+++ b/docs/source/idioms.rst
@@ -14,7 +14,6 @@ If we wanted to request two thousand urls, we wouldn't want to spawn two thousan
 
     import asks
     import curio
-    asks.init('curio')
 
     async def worker(sema, url):
         async with sema:
@@ -52,7 +51,6 @@ This sounds more confusing in writing than it is in code. Take a look: ::
 
     import asks
     import curio
-    asks.init('curio')
 
     results = {}
 
@@ -78,7 +76,6 @@ There are of course many ways to achieve this, but the above is noob friendly. A
 
     import asks
     import curio
-    asks.init('curio')
 
     results = []
     url_list = ["https://www.httpbin.org/get" for _ in range(50)]
@@ -109,7 +106,6 @@ The following examples use a context manager on the response body to ensure the 
 
     import asks
     import curio
-    asks.init('curio')
 
     async def main():
         r = await asks.get('http://httpbin.org/image/png', stream=True)
@@ -124,7 +120,6 @@ An example of multiple downloads with streaming: ::
 
     import asks
     import curio
-    asks.init('curio')
 
     from functools import partial
 
@@ -153,7 +148,6 @@ We define a callback function ``downloader`` that takes bytes and saves 'em, and
 
     import asks
     import curio
-    asks.init('curio')
 
     async def downloader(bytechunk):
         async with curio.aopen('our_image.png', 'ab') as out_file:
@@ -168,7 +162,6 @@ What about downloading a whole bunch of images, and naming them sequentially? ::
 
     import asks
     import curio
-    asks.init('curio')
 
     from functools import partial
 
@@ -192,7 +185,6 @@ Simply reference the ``Cookie`` 's ``.name`` and ``.value`` attributes as you pa
 
     import asks
     import curio
-    asks.init('curio')
 
     a_cookie = previous_response_object.cookies[0]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,8 +47,7 @@ Internally ``asks`` uses the excellent `h11 <https://github.com/njsmith/h11>`_. 
 Importing ``asks``
 __________________
 
-You must specify what event loop ``asks`` should use after importing, and at some point before you run any code that uses ``asks``.
-The event loop is set with ``asks.init()``. The following code will run the ``example`` coroutine once with ``curio`` and once with ``trio``: ::
+The following code will run the ``example`` coroutine once with ``curio`` and once with ``trio``: ::
 
     import asks
     import curio
@@ -57,13 +56,9 @@ The event loop is set with ``asks.init()``. The following code will run the ``ex
     async def example():
         r = await asks.get('https://example.org')
 
-    asks.init('curio')
     curio.run(example)
 
-    asks.init('trio')
     trio.run(example)
-
-If you forget to initialise ``asks`` with an event loop you'll get a ``RuntimeError``.
 
 
 A quick note on the examples in these docs

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,7 +76,6 @@ Here's how to grab a single request and print its content::
     # single_get.py
     import asks
     import curio
-    asks.init('curio')
 
     async def grabber(url):
         r = await asks.get(url)
@@ -104,7 +103,6 @@ We'll use the ``Session`` class here to take advantage of connection pooling.::
 
     import asks
     import curio
-    asks.init('curio')
 
     path_list = ['a', 'list', 'of', '1000', 'paths']
 

--- a/docs/source/overview-of-funcs-and-args.rst
+++ b/docs/source/overview-of-funcs-and-args.rst
@@ -261,7 +261,6 @@ You can stream the body of a response by setting ``stream=True`` , and iterating
 
     import asks
     import curio
-    asks.init('curio')
 
     async def main():
         r = await asks.get('http://httpbin.org/image/png', stream=True)
@@ -277,7 +276,6 @@ You can get around this by context-managering the ``.body`` if there is a chance
 
     import asks
     import curio
-    asks.init('curio')
 
     async def main():
         r = await asks.get('http://httpbin.com/image/png', stream=True)


### PR DESCRIPTION
The async library is now auto-detected.