### PR TITLE
Await coroutine from call to _location_auth_protect

### DIFF
--- a/asks/request_object.py
+++ b/asks/request_object.py
@@ -365,7 +365,7 @@ class RequestProcessor:
             location = urljoin(self.uri, location.strip())
             if self.auth is not None:
                 if not self.auth_off_domain:
-                    allow_redirect = self._location_auth_protect(location)
+                    allow_redirect = await self._location_auth_protect(location)
             self.uri = location
             l_scheme, l_netloc, *_ = urlparse(location)
             if l_scheme != self.scheme or l_netloc != self.host:


### PR DESCRIPTION
Fixes #182

When this coroutine is not awaited, its truth value (always True) is used instead of its return value, and `allow_redirect` becomes True just as long as these if's pass:

```python
if self.auth is not None:
    if not self.auth_off_domain:
        allow_redirect = self._location_auth_protect(location)
```