### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ async def example():
     r = await asks.get('https://example.org')
     print(r.content)
 
-curio.run(example())
+anyio.run(example)
 ```
 
 ```python


### PR DESCRIPTION
`anyio` is imported but it's not used, I assume you wanted to use it in place of `curio`.