### PR TITLE
bump anyio version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/theelous3/asks',
     packages=['asks'],
     python_requires='>= 3.6.2',
-    install_requires=['h11', 'async_generator', 'anyio ~= 3.0'],
+    install_requires=['h11', 'async_generator', 'anyio >= 3.0'],
     tests_require=['pytest', 'curio', 'trio', 'overly'],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
tests:
```
$ (uv venv test-anyio-4 && source test-anyio-4/bin/activate && uv pip install "anyio>=4.0,<5.0" pytest curio trio overly && uv pip install -e . && python -m pytest)
$ (uv venv test-anyio-3 && source test-anyio-3/bin/activate && uv pip install "anyio>=3.0,<4.0" pytest curio trio overly && uv pip install -e . && python -m pytest)
```

tests currently fail actually, but I think it's using a trio api that's deprecated